### PR TITLE
Fix crash on multiplayer servers

### DIFF
--- a/src/main/java/net/oblique/shoving_shovels/ShovingShovels.java
+++ b/src/main/java/net/oblique/shoving_shovels/ShovingShovels.java
@@ -32,7 +32,6 @@ public class ShovingShovels {
 
         //Register our mod's ModConfigSpec so that FML can create and load the config file for us (then add it to Neoforge's Config screen)
         modContainer.registerConfig(ModConfig.Type.COMMON, Config.SPEC);
-        modContainer.registerExtensionPoint(IConfigScreenFactory.class, ConfigurationScreen::new);
 
         modEventBus.addListener(this::onLoadComplete);
     }

--- a/src/main/java/net/oblique/shoving_shovels/ShovingShovelsClient.java
+++ b/src/main/java/net/oblique/shoving_shovels/ShovingShovelsClient.java
@@ -1,0 +1,17 @@
+package net.oblique.shoving_shovels;
+
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.bus.api.IEventBus;
+import net.neoforged.fml.ModContainer;
+import net.neoforged.fml.common.Mod;
+import net.neoforged.neoforge.client.gui.ConfigurationScreen;
+import net.neoforged.neoforge.client.gui.IConfigScreenFactory;
+
+@Mod(value = ShovingShovels.MODID, dist = Dist.CLIENT)
+public class ShovingShovelsClient {
+
+	//Initialization
+	public ShovingShovelsClient(IEventBus modEventBus, ModContainer modContainer) {
+		modContainer.registerExtensionPoint(IConfigScreenFactory.class, ConfigurationScreen::new);
+	}
+}


### PR DESCRIPTION
The mod crashes on startup in multiplayer when it loads `Screen`. This PR adds a proper client entrypoint that handles the config screen.